### PR TITLE
[feature/pre_tokenizer] Modify conversion script to use 'gpt-2' as the pre-tokenizer

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -616,7 +616,7 @@ class Model:
     def _set_vocab_gpt2(self) -> None:
         tokens, toktypes, tokpre = self.get_vocab_base()
         self.gguf_writer.add_tokenizer_model("gpt2")
-        self.gguf_writer.add_tokenizer_pre("llama-bpe")
+        self.gguf_writer.add_tokenizer_pre("gpt-2")
         self.gguf_writer.add_token_list(tokens)
         self.gguf_writer.add_token_types(toktypes)
 

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -616,7 +616,7 @@ class Model:
     def _set_vocab_gpt2(self) -> None:
         tokens, toktypes, tokpre = self.get_vocab_base()
         self.gguf_writer.add_tokenizer_model("gpt2")
-#         self.gguf_writer.add_tokenizer_pre(tokpre)
+        self.gguf_writer.add_tokenizer_pre("llama-bpe")
         self.gguf_writer.add_token_list(tokens)
         self.gguf_writer.add_token_types(toktypes)
 


### PR DESCRIPTION

## Update

- llama.cpp에서 42dot/42dot_LLM-PLM-1.3B의 체크포인트를 gguf 형으로 변환할 때 pre tokenizer를 "default"에서 "gpt-2"를 사용하도록 코드 수정

## MMLU 성능 비교

| default | llama-bpe | gpt-2 |
|----------|----------|----------|
| 31.4699  | 31.712   | 31.8687  |

- "gpt-2"는 "default" 대비 +0.3988
- ref : [llama.cpp 성능 비교표](https://docs.google.com/spreadsheets/d/1_qTqZYky0isMz-rS67lxWdlnov_ceIlJlq4XBeSB6xU/edit?gid=392349938#gid=392349938)

